### PR TITLE
Rental Orders: DACs, Graph, and Page (RC301000)

### DIFF
--- a/AcuBase/AcuBase.csproj
+++ b/AcuBase/AcuBase.csproj
@@ -58,6 +58,9 @@
     <Compile Include="CustomerExtension.cs" />
     <Compile Include="Examples.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="DAC\RCRentalOrder.cs" />
+    <Compile Include="DAC\RCRentalOrderLine.cs" />
+    <Compile Include="Graphs\RentalOrderEntry.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">

--- a/AcuBase/DAC/RCRentalOrder.cs
+++ b/AcuBase/DAC/RCRentalOrder.cs
@@ -1,0 +1,111 @@
+using System;
+using PX.Data;
+using PX.Data.BQL;
+using PX.Objects.AR;
+
+namespace AcuBase
+{
+    [Serializable]
+    [PXCacheName("Rental Order")]
+    [PXPrimaryGraph(typeof(Graphs.RentalOrderEntry))]
+    public partial class RCRentalOrder : IBqlTable
+    {
+        #region OrderNbr
+        public abstract class orderNbr : BqlString.Field<orderNbr> { }
+        [PXDBString(15, IsUnicode = true, IsKey = true, InputMask = ">CCCCCCCCCCCCCCC")]
+        [PXUIField(DisplayName = "Order Nbr")]
+        public virtual string OrderNbr { get; set; }
+        #endregion
+
+        #region CustomerID
+        public abstract class customerID : BqlInt.Field<customerID> { }
+        [PXDBInt]
+        [PXUIField(DisplayName = "Customer")]
+        [PXSelector(typeof(Search<Customer.bAccountID>),
+            SubstituteKey = typeof(Customer.acctCD),
+            DescriptionField = typeof(Customer.acctName))]
+        public virtual int? CustomerID { get; set; }
+        #endregion
+
+        #region OrderDate
+        public abstract class orderDate : BqlDateTime.Field<orderDate> { }
+        [PXDBDate]
+        [PXDefault(typeof(AccessInfo.businessDate))]
+        [PXUIField(DisplayName = "Order Date")]
+        public virtual DateTime? OrderDate { get; set; }
+        #endregion
+
+        #region DueDate
+        public abstract class dueDate : BqlDateTime.Field<dueDate> { }
+        [PXDBDate]
+        [PXUIField(DisplayName = "Due Date")]
+        public virtual DateTime? DueDate { get; set; }
+        #endregion
+
+        #region Status
+        public abstract class status : BqlString.Field<status> { }
+        [PXDBString(1, IsFixed = true)]
+        [PXUIField(DisplayName = "Status", Enabled = false)]
+        [PXDefault(RentalOrderStatuses.Hold)]
+        [PXStringList(new[] { RentalOrderStatuses.Hold, RentalOrderStatuses.Open, RentalOrderStatuses.Closed, RentalOrderStatuses.Canceled },
+                      new[] { "On Hold", "Open", "Closed", "Canceled" })]
+        public virtual string Status { get; set; }
+        #endregion
+
+        #region LineCntr
+        public abstract class lineCntr : BqlInt.Field<lineCntr> { }
+        [PXDBInt]
+        [PXDefault(0)]
+        [PXUIField(DisplayName = "Line Cntr", Enabled = false)]
+        public virtual int? LineCntr { get; set; }
+        #endregion
+
+        #region NoteID
+        public abstract class noteID : BqlGuid.Field<noteID> { }
+        [PXNote]
+        public virtual Guid? NoteID { get; set; }
+        #endregion
+
+
+        #region System Columns
+        public abstract class createdByID : BqlGuid.Field<createdByID> { }
+        [PXDBCreatedByID]
+        public virtual Guid? CreatedByID { get; set; }
+
+        public abstract class createdByScreenID : BqlString.Field<createdByScreenID> { }
+        [PXDBCreatedByScreenID]
+        public virtual string CreatedByScreenID { get; set; }
+
+        public abstract class createdDateTime : BqlDateTime.Field<createdDateTime> { }
+        [PXDBCreatedDateTime]
+        public virtual DateTime? CreatedDateTime { get; set; }
+
+        public abstract class lastModifiedByID : BqlGuid.Field<lastModifiedByID> { }
+        [PXDBLastModifiedByID]
+        public virtual Guid? LastModifiedByID { get; set; }
+
+        public abstract class lastModifiedByScreenID : BqlString.Field<lastModifiedByScreenID> { }
+        [PXDBLastModifiedByScreenID]
+        public virtual string LastModifiedByScreenID { get; set; }
+
+        public abstract class lastModifiedDateTime : BqlDateTime.Field<lastModifiedDateTime> { }
+        [PXDBLastModifiedDateTime]
+        public virtual DateTime? LastModifiedDateTime { get; set; }
+        #endregion
+
+        #region tstamp
+        public abstract class Tstamp : BqlByteArray.Field<Tstamp> { }
+        [PXDBTimestamp]
+        public virtual byte[] tstamp { get; set; }
+        #endregion
+    }
+
+    public static class RentalOrderStatuses
+    {
+        public const string Hold = "H";
+        public const string Open = "N";
+        public const string Closed = "C";
+        public const string Canceled = "X";
+    }
+}
+

--- a/AcuBase/DAC/RCRentalOrderLine.cs
+++ b/AcuBase/DAC/RCRentalOrderLine.cs
@@ -1,0 +1,101 @@
+using System;
+using PX.Data;
+using PX.Data.BQL;
+using PX.Objects.IN;
+
+namespace AcuBase
+{
+    [Serializable]
+    [PXCacheName("Rental Order Line")]
+    public partial class RCRentalOrderLine : IBqlTable
+    {
+        #region OrderNbr
+        public abstract class orderNbr : BqlString.Field<orderNbr> { }
+        [PXDBString(15, IsUnicode = true, IsKey = true)]
+        [PXDBDefault(typeof(RCRentalOrder.orderNbr))]
+        [PXParent(typeof(Select<RCRentalOrder, Where<RCRentalOrder.orderNbr, Equal<Current<RCRentalOrderLine.orderNbr>>>>))]
+        [PXUIField(DisplayName = "Order Nbr", Enabled = false)]
+        public virtual string OrderNbr { get; set; }
+        #endregion
+
+        #region LineNbr
+        public abstract class lineNbr : BqlInt.Field<lineNbr> { }
+        [PXDBInt(IsKey = true)]
+        [PXLineNbr(typeof(RCRentalOrder.lineCntr))]
+        [PXUIField(DisplayName = "Line Nbr", Enabled = false)]
+        public virtual int? LineNbr { get; set; }
+        #endregion
+
+        #region InventoryID
+        public abstract class inventoryID : BqlInt.Field<inventoryID> { }
+        [PXDBInt]
+        [PXUIField(DisplayName = "Inventory ID")]
+        [PXSelector(typeof(Search<InventoryItem.inventoryID>),
+            SubstituteKey = typeof(InventoryItem.inventoryCD),
+            DescriptionField = typeof(InventoryItem.descr))]
+        public virtual int? InventoryID { get; set; }
+        #endregion
+
+        #region TranDesc
+        public abstract class tranDesc : BqlString.Field<tranDesc> { }
+        [PXDBString(255, IsUnicode = true)]
+        [PXUIField(DisplayName = "Description")]
+        public virtual string TranDesc { get; set; }
+        #endregion
+
+        #region Qty
+        public abstract class qty : BqlDecimal.Field<qty> { }
+        [PXDBDecimal(6)]
+        [PXDefault(TypeCode.Decimal, "1.0")]
+        [PXUIField(DisplayName = "Qty")]
+        public virtual decimal? Qty { get; set; }
+        #endregion
+
+        #region UnitPrice
+        public abstract class unitPrice : BqlDecimal.Field<unitPrice> { }
+        [PXDBDecimal(6)]
+        [PXUIField(DisplayName = "Unit Price")]
+        public virtual decimal? UnitPrice { get; set; }
+        #endregion
+
+
+        #region System Columns
+        public abstract class createdByID : BqlGuid.Field<createdByID> { }
+        [PXDBCreatedByID]
+        public virtual Guid? CreatedByID { get; set; }
+
+        public abstract class createdByScreenID : BqlString.Field<createdByScreenID> { }
+        [PXDBCreatedByScreenID]
+        public virtual string CreatedByScreenID { get; set; }
+
+        public abstract class createdDateTime : BqlDateTime.Field<createdDateTime> { }
+        [PXDBCreatedDateTime]
+        public virtual DateTime? CreatedDateTime { get; set; }
+
+        public abstract class lastModifiedByID : BqlGuid.Field<lastModifiedByID> { }
+        [PXDBLastModifiedByID]
+        public virtual Guid? LastModifiedByID { get; set; }
+
+        public abstract class lastModifiedByScreenID : BqlString.Field<lastModifiedByScreenID> { }
+        [PXDBLastModifiedByScreenID]
+        public virtual string LastModifiedByScreenID { get; set; }
+
+        public abstract class lastModifiedDateTime : BqlDateTime.Field<lastModifiedDateTime> { }
+        [PXDBLastModifiedDateTime]
+        public virtual DateTime? LastModifiedDateTime { get; set; }
+        #endregion
+
+        #region NoteID
+        public abstract class noteID : BqlGuid.Field<noteID> { }
+        [PXNote]
+        public virtual Guid? NoteID { get; set; }
+        #endregion
+
+        #region tstamp
+        public abstract class Tstamp : BqlByteArray.Field<Tstamp> { }
+        [PXDBTimestamp]
+        public virtual byte[] tstamp { get; set; }
+        #endregion
+    }
+}
+

--- a/AcuBase/Graphs/RentalOrderEntry.cs
+++ b/AcuBase/Graphs/RentalOrderEntry.cs
@@ -1,0 +1,88 @@
+using System;
+using PX.Data;
+using PX.Data.BQL.Fluent;
+
+namespace AcuBase.Graphs
+{
+    public class RentalOrderEntry : PXGraph<RentalOrderEntry, AcuBase.RCRentalOrder>
+    {
+        public SelectFrom<AcuBase.RCRentalOrder>.View Document;
+        public SelectFrom<AcuBase.RCRentalOrderLine>
+            .Where<AcuBase.RCRentalOrderLine.orderNbr.IsEqual<AcuBase.RCRentalOrder.orderNbr.FromCurrent>>.View Details;
+
+        #region Actions
+        public PXAction<AcuBase.RCRentalOrder> PutOnHold;
+        [PXButton(CommitChanges = true)]
+        [PXUIField(DisplayName = "Put On Hold", MapEnableRights = PXCacheRights.Update, MapViewRights = PXCacheRights.Update)]
+        protected virtual void putOnHold()
+        {
+            var doc = Document.Current;
+            if (doc == null) return;
+            if (doc.Status != AcuBase.RentalOrderStatuses.Closed && doc.Status != AcuBase.RentalOrderStatuses.Canceled)
+            {
+                doc.Status = AcuBase.RentalOrderStatuses.Hold;
+                Document.Update(doc);
+                Actions.PressSave();
+            }
+        }
+
+        public PXAction<AcuBase.RCRentalOrder> ReleaseFromHold;
+        [PXButton(CommitChanges = true)]
+        [PXUIField(DisplayName = "Release From Hold", MapEnableRights = PXCacheRights.Update, MapViewRights = PXCacheRights.Update)]
+        protected virtual void releaseFromHold()
+        {
+            var doc = Document.Current;
+            if (doc == null) return;
+            if (doc.Status == AcuBase.RentalOrderStatuses.Hold)
+            {
+                doc.Status = AcuBase.RentalOrderStatuses.Open;
+                Document.Update(doc);
+                Actions.PressSave();
+            }
+        }
+
+        public PXAction<AcuBase.RCRentalOrder> CloseOrder;
+        [PXButton(CommitChanges = true)]
+        [PXUIField(DisplayName = "Close", MapEnableRights = PXCacheRights.Update, MapViewRights = PXCacheRights.Update)]
+        protected virtual void closeOrder()
+        {
+            var doc = Document.Current;
+            if (doc == null) return;
+            if (doc.Status == AcuBase.RentalOrderStatuses.Open)
+            {
+                doc.Status = AcuBase.RentalOrderStatuses.Closed;
+                Document.Update(doc);
+                Actions.PressSave();
+            }
+        }
+
+        public PXAction<AcuBase.RCRentalOrder> CancelOrder;
+        [PXButton(CommitChanges = true)]
+        [PXUIField(DisplayName = "Cancel", MapEnableRights = PXCacheRights.Update, MapViewRights = PXCacheRights.Update)]
+        protected virtual void cancelOrder()
+        {
+            var doc = Document.Current;
+            if (doc == null) return;
+            if (doc.Status != AcuBase.RentalOrderStatuses.Closed)
+            {
+                doc.Status = AcuBase.RentalOrderStatuses.Canceled;
+                Document.Update(doc);
+                Actions.PressSave();
+            }
+        }
+        #endregion
+
+        #region Event Handlers
+        protected virtual void _(Events.RowSelected<AcuBase.RCRentalOrder> e)
+        {
+            var row = e.Row;
+            if (row == null) return;
+            PutOnHold.SetEnabled(row.Status != AcuBase.RentalOrderStatuses.Hold && row.Status != AcuBase.RentalOrderStatuses.Closed);
+            ReleaseFromHold.SetEnabled(row.Status == AcuBase.RentalOrderStatuses.Hold);
+            CloseOrder.SetEnabled(row.Status == AcuBase.RentalOrderStatuses.Open);
+            CancelOrder.SetEnabled(row.Status != AcuBase.RentalOrderStatuses.Closed);
+        }
+        #endregion
+    }
+}
+

--- a/Pages/RC/RC301000.aspx
+++ b/Pages/RC/RC301000.aspx
@@ -1,0 +1,55 @@
+<%@ Page Language="C#" MasterPageFile="~/MasterPages/FormView.master" AutoEventWireup="true" ValidateRequest="false" Inherits="PX.Web.UI.PXPage" %>
+<%@ MasterType VirtualPath="~/MasterPages/FormView.master" %>
+
+<asp:Content ID="cont1" ContentPlaceHolderID="phDS" runat="server">
+	<px:PXDataSource ID="ds" runat="server" TypeName="AcuBase.Graphs.RentalOrderEntry" PrimaryView="Document">
+		<CallbackCommands>
+			<px:PXDSCallbackCommand Name="Save" PostData="Self" />
+		</CallbackCommands>
+	</px:PXDataSource>
+</asp:Content>
+
+<asp:Content ID="cont2" ContentPlaceHolderID="phF" runat="server">
+	<px:PXFormView ID="form" runat="server" DataSourceID="ds" DataMember="Document" Width="100%" Caption="Rental Order">
+		<Template>
+			<px:PXLayoutRule runat="server" StartColumn="True" LabelsWidth="SM" ControlSize="M" />
+			<px:PXSelector ID="edOrderNbr" runat="server" DataField="OrderNbr" />
+			<px:PXSelector ID="edCustomerID" runat="server" DataField="CustomerID" />
+			<px:PXDateTimeEdit ID="edOrderDate" runat="server" DataField="OrderDate" />
+			<px:PXDateTimeEdit ID="edDueDate" runat="server" DataField="DueDate" />
+			<px:PXDropDown ID="edStatus" runat="server" DataField="Status" Enabled="False" />
+		</Template>
+		<CallbackCommands>
+			<px:PXDSCallbackCommand Name="PutOnHold" Visible="True" />
+			<px:PXDSCallbackCommand Name="ReleaseFromHold" Visible="True" />
+			<px:PXDSCallbackCommand Name="CloseOrder" Visible="True" />
+			<px:PXDSCallbackCommand Name="CancelOrder" Visible="True" />
+		</CallbackCommands>
+	</px:PXFormView>
+</asp:Content>
+
+<asp:Content ID="cont3" ContentPlaceHolderID="phG" runat="server">
+	<px:PXGrid ID="grid" runat="server" DataSourceID="ds" Width="100%" SkinID="Details" Height="300px" AllowPaging="True">
+		<Levels>
+			<px:PXGridLevel DataMember="Details">
+				<Columns>
+					<px:PXGridColumn DataField="OrderNbr" Visible="False" />
+					<px:PXGridColumn DataField="LineNbr" Width="80px" />
+					<px:PXGridColumn DataField="InventoryID" Width="140px" />
+					<px:PXGridColumn DataField="TranDesc" Width="260px" />
+					<px:PXGridColumn DataField="Qty" Width="100px" TextAlign="Right" />
+					<px:PXGridColumn DataField="UnitPrice" Width="120px" TextAlign="Right" />
+				</Columns>
+			</px:PXGridLevel>
+		</Levels>
+		<ActionBar>
+			<CustomItems>
+				<px:PXToolBarButton CommandName="PutOnHold" Text="Put On Hold" />
+				<px:PXToolBarButton CommandName="ReleaseFromHold" Text="Release From Hold" />
+				<px:PXToolBarButton CommandName="CloseOrder" Text="Close" />
+				<px:PXToolBarButton CommandName="CancelOrder" Text="Cancel" />
+			</CustomItems>
+		</ActionBar>
+	</px:PXGrid>
+</asp:Content>
+


### PR DESCRIPTION
This PR introduces a basic VCD/DVD Rental Order feature.

Highlights
- DACs:
  - RCRentalOrder (header) with standard audit fields, NoteID, tstamp
  - RCRentalOrderLine (details) with standard audit fields, NoteID, tstamp
- Graph:
  - AcuBase.Graphs.RentalOrderEntry with Document/Details views and actions:
    PutOnHold, ReleaseFromHold, CloseOrder, CancelOrder
- Page:
  - RC301000.aspx bound to RentalOrderEntry with a form for header and grid for lines
- Project:
  - Updated AcuBase.csproj to include new DACs and Graph

Follow-ups (handled by remote agents in separate scripts)
- SQL tables for RCRentalOrder and RCRentalOrderLine (including PK/FK, indexes, audit columns, NoteID, tstamp)
- Sitemap entry for RC301000 under an appropriate workspace
- Optional: Numbering sequence (e.g., RCORDER) if you want AutoNumber on OrderNbr

Let me know if you want me to wire an AutoNumber attribute and where the screen should appear in the UI.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author